### PR TITLE
chore: adding remappings.txt

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,2 @@
+solmate/=lib/solmate/src/
+ds-test/=lib/ds-test/src


### PR DESCRIPTION
- adding `remappings.txt` to handle error importing packages on vscode.